### PR TITLE
Explicitly register the DC namespace.

### DIFF
--- a/umkcdora.module
+++ b/umkcdora.module
@@ -99,6 +99,7 @@ function umkcdora_islandora_view_object($object, $user, $page_number) {
     $doc = new DOMDocument();
     if (@$doc->loadXML($object['DC']->content)) {
       $xpath = new DOMXPath($doc);
+      $xpath->registerNamespace('dc', 'http://purl.org/dc/elements/1.1/');
       $title = $xpath->evaluate('string(//dc:title[1])');
       if (!empty($title)) {
         drupal_set_title($title);


### PR DESCRIPTION
If the DC namespace doesn't happen to be on the root element, XPath
would cause errors... Great fun!
